### PR TITLE
Fix source and link data on project files

### DIFF
--- a/services/getProjects.ts
+++ b/services/getProjects.ts
@@ -58,6 +58,8 @@ export const getProjectData = (id: string) => {
     subtitle: data.subtitle,
     description: data.description,
     date: data.date,
+    link: data.link,
+    source: data.source,
     content: content,
   };
 };


### PR DESCRIPTION
Bug was due to missing parameters on `getProjectData` function.