### PR TITLE
Add article on module federation vs native ESM

### DIFF
--- a/src/content/posts/module-federation-beats-native-esm.mdx
+++ b/src/content/posts/module-federation-beats-native-esm.mdx
@@ -1,0 +1,44 @@
+---
+title: "Module Federation Beats Native ESM at Scale"
+description: "What Zephyr's case against import-map-only architectures teaches about micro-frontend reality."
+image: "./images/proxmox1.webp"
+pubDate: "December 11 2025"
+expectedReadTime: 9
+tags: ["module-federation", "architecture", "microfrontends", "esm"]
+draft: false
+---
+
+If you only skimmed the "Module Federation vs Native ESM" piece from Zephyr, here’s the condensed, opinionated version: import maps and bare ESM feel elegant, but production micro-frontends need a runtime that negotiates versions, keeps singletons honest, and recovers when a remote flakes out. Module Federation exists precisely for that gap.
+
+## The dev‑experience cliff
+
+Cross-origin import maps scatter source maps, stack traces, and network waterfalls across multiple CDNs. Federation keeps everything in your app’s realm, so DevTools stays coherent and HMR works end-to-end. Zephyr’s plugins wire this into Webpack/Rspack/Vite without extra config, so you still ship one build and get a usable debugging story. citeturn0search0turn0search8
+
+## Ops and security reality
+
+Enterprise teams rarely route core dependencies through public CDNs; internal registries, SLAs, and air‑gapped deployments get in the way. Federation lets you host everything under your own domain while still resolving shared libraries at runtime. Zephyr leans into this with automatic dependency resolution and version management on its edge network, so you keep control without hand-curating import maps. citeturn0search1
+
+## Runtime flexibility beats static wiring
+
+Native ESM lacks a first-class notion of singletons or hot-swappable remotes. Module Federation ships those primitives: you can load a new remote when a feature flag flips, fallback to a safe build, or swap versions mid-session without page reloads. Zephyr adds lifecycle hooks and retry/backoff handling in the runtime layer, which matters when you have hundreds of remotes talking to each other. citeturn0search3
+
+## Performance is a bundler problem (and that’s fine)
+
+Import-map waterfalls explode into dozens of requests per dependency tree. Federation embraces bundlers for code splitting, tree shaking, and parallel preloading. Zephyr’s bundler plugins handle the manifest wiring for you and ship to its global edge, so you keep optimized chunks without writing custom loaders. citeturn0search0turn0search10
+
+## Beyond the web: same playbook on mobile
+
+React Native, Metro, and Re.Pack are getting first-class federation support, letting you ship “mini-apps” without app-store resubmits. The constraints (single React runtime, shared native modules) mirror the browser story, and the same Zephyr runtime bridges the gap. citeturn0search6
+
+## When plain ESM is enough
+
+Small docs sites, prototypes, or single-team tools can live happily on import maps—especially when the dependency graph is shallow and uptime isn’t mission critical. The moment you’re coordinating multiple teams, long-lived tabs, or strict compliance zones, the overhead of manual version alignment outweighs the simplicity of bare ESM.
+
+## A pragmatic adoption path
+
+1. Start with a single host/remote pair behind a feature flag; exercise failure modes and fallbacks.  
+2. Turn on shared singletons for React/state libraries first; keep everything else local until confidence grows.  
+3. Add observability hooks (load timing, retries, error boundaries) before multiplying remotes.  
+4. Only mirror to import maps for the simplest, latency-tolerant widgets.
+
+Module Federation isn’t “anti-standard”; it’s the guardrails layer standards don’t yet provide. If your frontend is starting to look like a distributed system, choose the runtime that treats it like one. And if you want less yak-shaving, the Zephyr ecosystem gives you the batteries: deploys, manifests, version negotiation, and rollbacks in one place. citeturn0search9


### PR DESCRIPTION
- add new post summarizing why module federation outscales native import-map ESM
- reuse existing image and publish date Dec 11 2025
- ready for content review